### PR TITLE
Fix V768 warning from PVS-Studio Static Analyzer

### DIFF
--- a/id_sd.cpp
+++ b/id_sd.cpp
@@ -585,7 +585,7 @@ void SD_PrepareSound(int which)
 
 int SD_PlayDigitized(word which,int leftpos,int rightpos)
 {
-    if (!DigiMode)
+    if (DigiMode == sds_Off)
         return 0;
 
     if (which >= NumDigi)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The variable 'DigiMode' is of enum type.
It is odd that it is used as a variable of a Boolean-type.