### PR TITLE
Fix V576 warning from PVS-Studio Static Analyzer

### DIFF
--- a/id_us_1.cpp
+++ b/id_us_1.cpp
@@ -177,7 +177,7 @@ void
 US_PrintUnsigned(longword n)
 {
 	char	buffer[32];
-	sprintf(buffer, "%lu", n);
+        sprintf(buffer, "%u", n);
 
 	US_Print(buffer);
 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Incorrect format. Consider checking the third actual argument
of the 'sprintf' function. The memsize type argument is expected.