### PR TITLE
Fix V614 warning from PVS-Studio Static Analyzer

### DIFF
--- a/id_us_1.cpp
+++ b/id_us_1.cpp
@@ -492,7 +492,7 @@ US_LineInput(int x,int y,char *buf,const char *def,boolean escok,
 	ScanCode	sc;
 	char		c;
 	char		s[MaxString],olds[MaxString];
-	int         cursor,len;
+        int         cursor,len=0;
 	word		i,
 				w,h,
 				temp;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Uninitialized variable 'len' used.